### PR TITLE
CSS is an acronym

### DIFF
--- a/colors/rivotti256.vim
+++ b/colors/rivotti256.vim
@@ -101,7 +101,7 @@ hi def link javaScriptDOMProperties         Constant
 hi def link javaScriptHtmlElemProperties    Constant
 hi def link javaScriptParens                Normal
 
-" Css
+" CSS
 hi def link cssVendor   Type
 
 " Markdown


### PR DESCRIPTION
CSS is an acronym, it means Cascading Style Sheets.
Thus, it shouldn't be called as "Css", but properly capitalized as "CSS".
